### PR TITLE
skip hub CreateIntent when enriched relayer create exists

### DIFF
--- a/api/db.js
+++ b/api/db.js
@@ -17,10 +17,12 @@ pool.on('error', function (error, client) {
 })
 
 // Hub-origin rows are written into `messages` with sn = NULL; relayer rows
-// have sn IS NOT NULL. They share the same `intent_tx_hash`, so for
-// spoke-originated intents an intent's CreateIntent appears twice: once as
-// the cross-chain message (relayer) and once as the on-chain hub event
-// (hub poller). The intent-siblings panel groups them.
+// have sn IS NOT NULL. They share the same `intent_tx_hash`. The hub
+// poller skips its CreateIntent row when the relayer already has an
+// enriched one (spoke-originated creation), so an intent normally has a
+// single CreateIntent. A hub create row with no relayer twin means the
+// intent was created directly on the hub — or the relay row never
+// enriched and the hub event is the only usable record.
 
 const buildWhereSql = (status, src_network, dest_network, src_address, dest_address, from_timestamp, to_timestamp, action_type, intent_tx_hash) => {
     let values = []

--- a/indexer/scripts/cleanup-duplicate-hub-creates.ts
+++ b/indexer/scripts/cleanup-duplicate-hub-creates.ts
@@ -1,0 +1,76 @@
+/**
+ * Remove hub-origin CreateIntent rows that duplicate an enriched relayer
+ * CreateIntent for the same intent.
+ *
+ * For spoke-originated intents the creation is indexed twice: the relayer
+ * writes the cross-chain message row and the hub poller writes the
+ * on-chain IntentCreated event row. The poller now skips its row when the
+ * relayer's is already enriched (insertHubEventAsMessage guard), but:
+ *   - rows from before that guard exist, and
+ *   - the guard can't catch the window where the relay row exists but
+ *     isn't enriched yet (still 'SendMsg') at hub-insert time.
+ * This sweep deletes those duplicates. Safe to re-run any time — e.g.
+ * periodically, to mop up the race-window stragglers.
+ *
+ * A hub create row is deleted ONLY when an enriched relayer CreateIntent
+ * with the same intent_tx_hash exists. Hub creates whose relay twin is
+ * missing or stuck unenriched are kept — they're the only usable record
+ * of the creation.
+ *
+ * Dry run by default — prints count + sample. Pass --apply to delete.
+ */
+
+import 'dotenv/config';
+import { Pool } from 'pg';
+
+const apply = process.argv.includes('--apply');
+
+const pool = new Pool({
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  port: Number(process.env.DB_PORT || 5432),
+  ssl: { rejectUnauthorized: false },
+});
+
+const WHERE = `
+  m.sn IS NULL
+  AND m.action_type = 'CreateIntent'
+  AND EXISTS (
+    SELECT 1 FROM messages r
+    WHERE r.intent_tx_hash = m.intent_tx_hash
+      AND r.action_type    = 'CreateIntent'
+      AND r.sn IS NOT NULL
+  )
+`;
+
+async function main(): Promise<void> {
+  const count = Number(
+    (await pool.query(`SELECT count(*) AS n FROM messages m WHERE ${WHERE}`)).rows[0].n,
+  );
+  console.log(`duplicate hub creates in scope: ${count}`);
+
+  const sample = await pool.query(
+    `SELECT m.id, m.intent_tx_hash, LEFT(m.action_detail, 60) AS detail
+       FROM messages m WHERE ${WHERE} ORDER BY m.id DESC LIMIT 5`,
+  );
+  for (const r of sample.rows) {
+    console.log(`  id=${r.id} intent=${r.intent_tx_hash} ${r.detail}`);
+  }
+
+  if (!apply) {
+    console.log('\nDry run — nothing deleted. Re-run with --apply to delete.');
+    await pool.end();
+    return;
+  }
+
+  const rs = await pool.query(`DELETE FROM messages m WHERE ${WHERE}`);
+  console.log(`deleted ${rs.rowCount} row(s).`);
+  await pool.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/indexer/src/hub-intents/repo.ts
+++ b/indexer/src/hub-intents/repo.ts
@@ -3,10 +3,11 @@ import * as path from 'node:path';
 import pool from '../db/db';
 
 // Hub events go into the `messages` table with sn = NULL as the hub-origin
-// marker. Creates are written for every IntentCreated event on the hub
-// contract; fills/cancels are written only when intra-hub (dst=sonic), since
-// cross-chain fill/cancel deliveries already land in messages via the
-// relayer.
+// marker. Creates are written for IntentCreated events on the hub contract
+// unless the relayer already has an enriched CreateIntent row for the
+// intent (spoke-originated creation); fills/cancels are written only when
+// intra-hub (dst=sonic), since cross-chain fill/cancel deliveries already
+// land in messages via the relayer.
 
 export interface HubEventRow {
   intentHash: string;
@@ -36,11 +37,21 @@ export interface CreatedContext {
 
 const nowSec = () => Math.floor(Date.now() / 1000);
 
-// Insert a hub event as a messages row with sn = NULL. WHERE NOT EXISTS
-// Returns true when a row was written, false when the WHERE NOT EXISTS
-// matched (i.e. the same (intent_tx_hash, action_type, sn IS NULL) was
-// already present). Lets the caller surface a write/skip ratio for
-// monitoring.
+// Insert a hub event as a messages row with sn = NULL.
+// Returns true when a row was written, false when a guard matched (no
+// write). Lets the caller surface a write/skip ratio for monitoring.
+//
+// Two guards:
+//   1. The same (intent_tx_hash, action_type, sn IS NULL) row already
+//      exists — idempotency for cursor replays.
+//   2. CreateIntent only: the relayer already has an enriched CreateIntent
+//      row for this intent (spoke-originated creation, fully indexed) —
+//      a hub create row would only duplicate it. An unenriched relay row
+//      (still 'SendMsg') does NOT block the insert: enrichment can fail
+//      permanently (e.g. a stale RPC), and then the hub row is the only
+//      usable record. The brief window where the relay row exists but
+//      isn't enriched yet can still produce a duplicate — the
+//      cleanup-duplicate-hub-creates script sweeps those.
 export async function insertHubEventAsMessage(row: HubEventRow): Promise<boolean> {
   const status = row.eventType === 'cancelled' ? 'rollbacked' : 'executed';
   const now = nowSec();
@@ -62,6 +73,15 @@ export async function insertHubEventAsMessage(row: HubEventRow): Promise<boolean
       WHERE intent_tx_hash = $11::varchar
         AND action_type    = $9::varchar
         AND sn IS NULL
+    )
+    AND NOT (
+      $9::varchar = 'CreateIntent'
+      AND EXISTS (
+        SELECT 1 FROM messages
+        WHERE intent_tx_hash = $11::varchar
+          AND action_type    = 'CreateIntent'
+          AND sn IS NOT NULL
+      )
     )
   `;
   const result = await pool.query(sql, [


### PR DESCRIPTION
For spoke-originated intents the creation was indexed twice: the relayer's cross-chain message row and the poller's on-chain IntentCreated row. The insert now skips the hub copy when the relayer row is already enriched, folded into the existing INSERT's guard so it stays a single statement. Unenriched relay rows don't block the insert — enrichment can fail permanently and the hub row is then the only usable record. Sweep script removes pre-existing duplicates and race-window stragglers; safe to re-run.