### PR TITLE
close hub/relay duplicate race for all intent event types

### DIFF
--- a/indexer/scripts/cleanup-duplicate-hub-creates.ts
+++ b/indexer/scripts/cleanup-duplicate-hub-creates.ts
@@ -1,21 +1,18 @@
 /**
- * Remove hub-origin CreateIntent rows that duplicate an enriched relayer
- * CreateIntent for the same intent.
+ * Remove hub-origin rows that duplicate an enriched relayer row for the
+ * same event (same intent_tx_hash + action_type).
  *
- * For spoke-originated intents the creation is indexed twice: the relayer
- * writes the cross-chain message row and the hub poller writes the
- * on-chain IntentCreated event row. The poller now skips its row when the
- * relayer's is already enriched (insertHubEventAsMessage guard), but:
- *   - rows from before that guard exist, and
- *   - the guard can't catch the window where the relay row exists but
- *     isn't enriched yet (still 'SendMsg') at hub-insert time.
- * This sweep deletes those duplicates. Safe to re-run any time — e.g.
- * periodically, to mop up the race-window stragglers.
+ * Steady-state this can't happen anymore: the poller skips its insert
+ * when the enriched relay row exists (insertHubEventAsMessage), and
+ * enrichment deletes the hub copy when it lands after the poller wrote
+ * one (updateTransactionInfo). This script is the one-time cleanup for
+ * rows from before those guards, and an on-demand consistency check —
+ * safe to re-run any time; in a healthy system it finds 0 rows.
  *
- * A hub create row is deleted ONLY when an enriched relayer CreateIntent
- * with the same intent_tx_hash exists. Hub creates whose relay twin is
+ * A hub row is deleted ONLY when an enriched relayer row with the same
+ * intent_tx_hash and action_type exists. Hub rows whose relay twin is
  * missing or stuck unenriched are kept — they're the only usable record
- * of the creation.
+ * of the event.
  *
  * Dry run by default — prints count + sample. Pass --apply to delete.
  */
@@ -36,27 +33,28 @@ const pool = new Pool({
 
 const WHERE = `
   m.sn IS NULL
-  AND m.action_type = 'CreateIntent'
   AND EXISTS (
     SELECT 1 FROM messages r
     WHERE r.intent_tx_hash = m.intent_tx_hash
-      AND r.action_type    = 'CreateIntent'
+      AND r.action_type    = m.action_type
       AND r.sn IS NOT NULL
   )
 `;
 
 async function main(): Promise<void> {
-  const count = Number(
-    (await pool.query(`SELECT count(*) AS n FROM messages m WHERE ${WHERE}`)).rows[0].n,
+  const byType = await pool.query(
+    `SELECT m.action_type, count(*) AS n FROM messages m WHERE ${WHERE} GROUP BY 1 ORDER BY 2 DESC`,
   );
-  console.log(`duplicate hub creates in scope: ${count}`);
+  const total = byType.rows.reduce((s, r) => s + Number(r.n), 0);
+  console.log(`duplicate hub rows in scope: ${total}`);
+  for (const r of byType.rows) console.log(`  ${r.action_type}: ${r.n}`);
 
   const sample = await pool.query(
-    `SELECT m.id, m.intent_tx_hash, LEFT(m.action_detail, 60) AS detail
+    `SELECT m.id, m.action_type, m.intent_tx_hash, LEFT(m.action_detail, 50) AS detail
        FROM messages m WHERE ${WHERE} ORDER BY m.id DESC LIMIT 5`,
   );
   for (const r of sample.rows) {
-    console.log(`  id=${r.id} intent=${r.intent_tx_hash} ${r.detail}`);
+    console.log(`  id=${r.id} ${r.action_type} intent=${r.intent_tx_hash} ${r.detail}`);
   }
 
   if (!apply) {

--- a/indexer/src/db/index.ts
+++ b/indexer/src/db/index.ts
@@ -17,6 +17,23 @@ export async function updateTransactionInfo(id: number, fee: string, actionType:
     `;
     await client.query(updateQuery, [fee, actionType, actionText, intentTxHash, slippage, blockNumber, id]);
 
+    // This enrichment is the last writer for an intent event: the relayer
+    // row is now the authoritative record, so a hub-poller copy of the
+    // same event (sn IS NULL — only the poller writes those) is redundant.
+    // Deleting it here, in the same transaction, closes the race the
+    // poller's insert guard can't see: when the hub row landed before this
+    // relay row was enriched. The opposite order is covered by the guard
+    // in insertHubEventAsMessage.
+    if (intentTxHash) {
+      await client.query(
+        `DELETE FROM messages
+          WHERE sn IS NULL
+            AND intent_tx_hash = $1
+            AND action_type    = $2`,
+        [intentTxHash, actionType],
+      );
+    }
+
     await client.query('COMMIT');
   } catch (err) {
     await client.query('ROLLBACK');

--- a/indexer/src/hub-intents/repo.ts
+++ b/indexer/src/hub-intents/repo.ts
@@ -3,11 +3,11 @@ import * as path from 'node:path';
 import pool from '../db/db';
 
 // Hub events go into the `messages` table with sn = NULL as the hub-origin
-// marker. Creates are written for IntentCreated events on the hub contract
-// unless the relayer already has an enriched CreateIntent row for the
-// intent (spoke-originated creation); fills/cancels are written only when
-// intra-hub (dst=sonic), since cross-chain fill/cancel deliveries already
-// land in messages via the relayer.
+// marker. Every event type skips its insert when the relayer already has
+// an enriched row for the same event (see insertHubEventAsMessage);
+// fills/cancels additionally are written only when intra-hub (dst=sonic),
+// since cross-chain fill deliveries already land in messages via the
+// relayer.
 
 export interface HubEventRow {
   intentHash: string;
@@ -44,14 +44,14 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 // Two guards:
 //   1. The same (intent_tx_hash, action_type, sn IS NULL) row already
 //      exists — idempotency for cursor replays.
-//   2. CreateIntent only: the relayer already has an enriched CreateIntent
-//      row for this intent (spoke-originated creation, fully indexed) —
-//      a hub create row would only duplicate it. An unenriched relay row
-//      (still 'SendMsg') does NOT block the insert: enrichment can fail
-//      permanently (e.g. a stale RPC), and then the hub row is the only
-//      usable record. The brief window where the relay row exists but
-//      isn't enriched yet can still produce a duplicate — the
-//      cleanup-duplicate-hub-creates script sweeps those.
+//   2. The relayer already has an enriched row for the same event (same
+//      intent + action_type, sn IS NOT NULL) — a hub copy would only
+//      duplicate it. An unenriched relay row (still 'SendMsg') does NOT
+//      block the insert: enrichment can fail permanently (e.g. a stale
+//      RPC), and then the hub row is the only usable record. The brief
+//      window where the relay row exists but isn't enriched yet can still
+//      produce a duplicate — updateTransactionInfo deletes the hub copy
+//      when the relay row's enrichment lands.
 export async function insertHubEventAsMessage(row: HubEventRow): Promise<boolean> {
   const status = row.eventType === 'cancelled' ? 'rollbacked' : 'executed';
   const now = nowSec();
@@ -74,14 +74,11 @@ export async function insertHubEventAsMessage(row: HubEventRow): Promise<boolean
         AND action_type    = $9::varchar
         AND sn IS NULL
     )
-    AND NOT (
-      $9::varchar = 'CreateIntent'
-      AND EXISTS (
-        SELECT 1 FROM messages
-        WHERE intent_tx_hash = $11::varchar
-          AND action_type    = 'CreateIntent'
-          AND sn IS NOT NULL
-      )
+    AND NOT EXISTS (
+      SELECT 1 FROM messages
+      WHERE intent_tx_hash = $11::varchar
+        AND action_type    = $9::varchar
+        AND sn IS NOT NULL
     )
   `;
   const result = await pool.query(sql, [


### PR DESCRIPTION
Two-sided, order-independent dedupe between the hub poller and the relayer for the same intent event (intent_tx_hash + action_type):

- poller skips its insert when an enriched relay row already exists (guard generalized from CreateIntent to all event types)
- enrichment deletes the hub copy in the same transaction when it lands after the poller already wrote one (the case the insert guard cannot see)

Either writer can finish first; the loser yields. Hub rows with no enriched relay twin are never touched — when enrichment fails permanently they are the only usable record. The sweep script is now a one-time cleanup / on-demand consistency check (finds 0 in steady state) and covers all event types, e.g. the 620 duplicate cancels written under the old dst-axis skip.