### PR TITLE
label fill/cancel per message, not per tx

### DIFF
--- a/indexer/scripts/probe-fill-sender-rule.ts
+++ b/indexer/scripts/probe-fill-sender-rule.ts
@@ -1,0 +1,160 @@
+/**
+ * Validation probe for the sender-based IntentFilled discriminator.
+ *
+ * Rule under test: a relay Message in a fill tx is THE fill delivery iff
+ * its payload sender field equals the contract that emitted the
+ * IntentFilled event in the same tx. Everything else in the tx is a
+ * plain transfer (solver side-moves), regardless of token names.
+ *
+ * Samples historical Sonic fill txs from `messages` and reports:
+ *   - per-tx: #Message events, #messages matching the sender rule
+ *   - invariant violations (0 matches, or more matches than IntentFilled
+ *     events in the tx — batch fills legitimately have several)
+ *   - disagreements between the rule and current DB labels (expected:
+ *     exactly the mislabeled siblings)
+ *
+ * Read-only. Usage: ts-node scripts/probe-fill-sender-rule.ts [sampleSize]
+ */
+
+import 'dotenv/config';
+import { ethers } from 'ethers';
+import { Pool } from 'pg';
+
+const SAMPLE = Number(process.argv[2] || 200);
+
+const MESSAGE_EVENT_TOPIC = ethers.keccak256(
+  ethers.toUtf8Bytes('Message(uint256,bytes,uint256,uint256,bytes,bytes)'),
+);
+const INTENT_FILLED_TOPIC = ethers.keccak256(
+  ethers.toUtf8Bytes('IntentFilled(bytes32,(bool,uint256,uint256,bool))'),
+);
+
+const pool = new Pool({
+  user: process.env.DB_USER,
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  password: process.env.DB_PASSWORD,
+  port: Number(process.env.DB_PORT || 5432),
+  ssl: { rejectUnauthorized: false },
+});
+
+const provider = new ethers.JsonRpcProvider(process.env.SONIC_URL);
+const abi = ethers.AbiCoder.defaultAbiCoder();
+
+// Payload sender: field 1 of the 5-field RLP transfer payload.
+function payloadSender(payload: string): string | null {
+  try {
+    const rlp = ethers.decodeRlp(payload);
+    if (!Array.isArray(rlp) || rlp.length !== 5) return null;
+    return String(rlp[1]).toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  // Mix: txs that produced >1 IntentFilled-labeled rows (suspect) and
+  // single-fill txs (control), most recent first.
+  const txs = await pool.query(
+    `SELECT src_tx_hash, count(*) AS fill_rows
+       FROM messages
+      WHERE sn IS NOT NULL AND action_type = 'IntentFilled' AND src_network = '146'
+      GROUP BY src_tx_hash
+      ORDER BY max(id) DESC
+      LIMIT $1`,
+    [SAMPLE],
+  );
+
+  let txsOk = 0;
+  let txsNoMatch = 0;
+  let txsExcessMatch = 0;
+  let rpcOrDecodeIssues = 0;
+  const disagreements: string[] = [];
+  let agreements = 0;
+
+  for (const row of txs.rows) {
+    const txHash = row.src_tx_hash;
+    let rcpt: ethers.TransactionReceipt | null = null;
+    try {
+      rcpt = await provider.getTransactionReceipt(txHash);
+    } catch {
+      /* fall through */
+    }
+    if (!rcpt) {
+      rpcOrDecodeIssues++;
+      continue;
+    }
+
+    const fillEmitters = new Set<string>();
+    let fillEventCount = 0;
+    for (const log of rcpt.logs) {
+      if (log.topics[0] === INTENT_FILLED_TOPIC) {
+        fillEmitters.add(log.address.toLowerCase());
+        fillEventCount++;
+      }
+    }
+    if (fillEventCount === 0) {
+      // DB says fill but no event on chain — different problem, just count.
+      rpcOrDecodeIssues++;
+      continue;
+    }
+
+    // Apply the rule to every Message event in the tx.
+    const verdicts: Array<{ sn: string; isFill: boolean }> = [];
+    for (const log of rcpt.logs) {
+      if (log.topics[0] !== MESSAGE_EVENT_TOPIC) continue;
+      const d = abi.decode(['uint256', 'bytes', 'uint256', 'uint256', 'bytes', 'bytes'], log.data);
+      const sender = payloadSender(d[5]);
+      verdicts.push({
+        sn: BigInt(d[2]).toString(),
+        isFill: sender !== null && fillEmitters.has(sender),
+      });
+    }
+
+    const matches = verdicts.filter(v => v.isFill).length;
+    if (verdicts.length > 0 && matches === 0) {
+      txsNoMatch++;
+      console.log(`NO-MATCH   ${txHash} msgs=${verdicts.length} fillEvents=${fillEventCount}`);
+    } else if (matches > fillEventCount) {
+      txsExcessMatch++;
+      console.log(`EXCESS     ${txHash} matches=${matches} fillEvents=${fillEventCount}`);
+    } else {
+      txsOk++;
+    }
+
+    // Compare rule verdicts against DB labels for this tx.
+    const dbRows = await pool.query(
+      `SELECT sn, action_type FROM messages WHERE src_tx_hash = $1 AND sn IS NOT NULL`,
+      [txHash],
+    );
+    for (const dbRow of dbRows.rows) {
+      const v = verdicts.find(x => x.sn === String(dbRow.sn));
+      if (!v) continue;
+      const dbSaysFill = dbRow.action_type === 'IntentFilled';
+      if (dbSaysFill === v.isFill) {
+        agreements++;
+      } else {
+        disagreements.push(
+          `  sn=${dbRow.sn} db=${dbRow.action_type} rule=${v.isFill ? 'IntentFilled' : 'Transfer'} tx=${txHash}`,
+        );
+      }
+    }
+  }
+
+  console.log(`\ntxs sampled: ${txs.rows.length}`);
+  console.log(`  rule consistent (matches <= fill events, >=1): ${txsOk}`);
+  console.log(`  NO message matched sender rule:                ${txsNoMatch}`);
+  console.log(`  more matches than fill events:                 ${txsExcessMatch}`);
+  console.log(`  rpc/decode issues (skipped):                   ${rpcOrDecodeIssues}`);
+  console.log(`\nrow-level vs DB labels: ${agreements} agree, ${disagreements.length} disagree`);
+  console.log('disagreements (expected = mislabeled siblings):');
+  for (const d of disagreements.slice(0, 40)) console.log(d);
+  if (disagreements.length > 40) console.log(`  ... +${disagreements.length - 40} more`);
+
+  await pool.end();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/indexer/src/chains/evm/index.ts
+++ b/indexer/src/chains/evm/index.ts
@@ -48,6 +48,10 @@ export class EvmHandler implements ChainHandler {
     let intentFilledAction = ""
     let intentFilledValue = 0
     let intentHash = ""
+    // Contracts that emitted an intent event in this tx — used below to
+    // decide whether THIS message (txConnSn) is the fill/cancel delivery
+    // or an unrelated message riding along in the same tx.
+    const intentEventEmitters = new Set<string>()
     for (const log of tx.result.logs ?? []) {
       const topics: string[] = log.topics;
       if (topics.includes(INTENT_CREATED_TOPIC)) {
@@ -70,6 +74,7 @@ export class EvmHandler implements ChainHandler {
         intentFilledAction = `IntentFilled ${decoded[0]}`
         intentFilledValue = decoded[0][3]
         intentHash = decoded[0][0]
+        intentEventEmitters.add(String(log.address).toLowerCase())
       }
       if (topics.includes(INTENT_CANCELLED_TOPIC)) {
         intentCancelled = true
@@ -77,12 +82,39 @@ export class EvmHandler implements ChainHandler {
         const decoded = abi.decode(['bytes32'], log.data);
         intentCancelAction = `IntentCancelled ${decoded[0]}`
         intentHash = decoded[0]
+        intentEventEmitters.add(String(log.address).toLowerCase())
       }
       if (topics.includes(REVERSE_SWAP_TOPIC)) {
         reverseSwap = true
         const abi = ethers.AbiCoder.defaultAbiCoder();
         const decoded = abi.decode(['uint256', 'uint256'], log.data);
         reverseSwapAction = `Migrated ${bigintDivisionToDecimalString(decoded[1], 18)} Soda`
+      }
+    }
+    // Per-message fill/cancel gate. The intent events above describe the
+    // TX as a whole, but a solver tx can carry several relay messages
+    // (e.g. the fill delivery plus the solver's own transfers). Only the
+    // message whose payload was dispatched BY the intent contract is the
+    // fill/cancel delivery; siblings are plain messages and must be
+    // returned as such, or they'd all inherit the IntentFilled label
+    // (the recurring "intent filled collision" — token-name heuristics
+    // downstream cannot distinguish same-token siblings).
+    if (intentFilled || intentCancelled) {
+      const msg = findMessageEventBySn(tx.result.logs ?? [], txConnSn);
+      if (msg) {
+        const sender = transferPayloadSender(msg.payload);
+        if (sender !== null && !intentEventEmitters.has(sender)) {
+          return {
+            txnFee: `${bigintDivisionToDecimalString(txFee, 18)} ${this.denom}`,
+            payload: msg.payload,
+            intentFilled: false,
+            intentCancelled: false,
+            dstAddress: tx.result.to,
+            intentTxHash: intentHash,
+            blockNumber: Number.parseInt(tx.result.blockNumber, 16),
+            storedCallReverted,
+          };
+        }
       }
     }
     if (!intentFilled && !intentCancelled && !reverseSwap) {
@@ -186,40 +218,6 @@ export class EvmHandler implements ChainHandler {
                   const srcChainId = result[8]
                   const dstChainId = result[9]
                   intentMinOutput = result[5]
-                  const dstToken = result[3]
-                  for (const log of tx.result.logs ?? []) {
-                    const topics: string[] = log.topics;
-                    if (topics.includes(MESSAGE_EVENT_TOPIC)) {
-                      const abi = ethers.AbiCoder.defaultAbiCoder();
-                      const decoded = abi.decode(['uint256', 'bytes', 'uint256', 'uint256', 'bytes', 'bytes'], log.data);
-                      const payload = decoded[5];
-                      const connSn = decoded[2]
-                      const msgDstChainId = decoded[3]
-                      const intentDenom = getTokenDenom(dstToken.toLowerCase(), BigInt(dstChainId).toString(), BigInt(srcChainId).toString())
-                      const payloadDenom = this.parsePayloadData(payload, BigInt(dstChainId).toString(), BigInt(srcChainId).toString())
-                      if (BigInt(connSn).toString() === BigInt(txConnSn).toString()) {
-                        if (intentDenom !== payloadDenom || msgDstChainId !== dstChainId) {
-                          if (intentDenom.includes("USDC") && payloadDenom.includes("USDC")) {
-                            continue
-                          }
-                          if (intentDenom.includes("BTCB") && payloadDenom.includes("BTCB")) {
-                            continue
-                          }
-                          intentFilled = false
-                          return {
-                            txnFee: `${bigintDivisionToDecimalString(txFee, 18)} ${this.denom}`,
-                            payload: payload,
-                            intentFilled,
-                            intentCancelled,
-                            dstAddress: tx.result.to,
-                            intentTxHash: intentHash,
-                            blockNumber: Number.parseInt(tx.result.blockNumber, 16),
-                            storedCallReverted,
-                          };
-                        }
-                      }
-                    }
-                  }
                   const assetsInformation = chains[srcChainId].Assets
                   let inputToken = result[2].toLowerCase()
                   let decimals = 18
@@ -266,12 +264,8 @@ export class EvmHandler implements ChainHandler {
             if (intentFilled) {
               const parsed = this.parseFilledIntentFromInput(
                 inputData,
-                tx.result.logs ?? [],
-                txConnSn,
-                tx.result.to,
                 intentFilledValue,
                 intentHash,
-                intentCancelled,
                 txFee,
                 Number.parseInt(tx.result.blockNumber, 16),
                 storedCallReverted,
@@ -327,12 +321,8 @@ export class EvmHandler implements ChainHandler {
 
   private parseFilledIntentFromInput(
     inputData: string,
-    logs: Array<{ topics: string[]; data: string }>,
-    txConnSn: string,
-    dstAddress: string,
     intentFilledValue: number,
     intentHash: string,
-    intentCancelled: boolean,
     txFee: bigint,
     blockNumber: number,
     storedCallReverted: boolean,
@@ -355,35 +345,6 @@ export class EvmHandler implements ChainHandler {
         const dstChain = chains[dstChainId];
         if (!srcChain || !dstChain) {
           continue;
-        }
-        // Cross-check the Message log: if the intent's dst token denom or
-        // dstChainId doesn't match the message payload for this connSn, this
-        // tx is actually a regular message (multi-intent fill case), not an
-        // intent fill for the current message.
-        const dstToken = intent[3];
-        for (const log of logs) {
-          if (!log.topics?.includes(MESSAGE_EVENT_TOPIC)) continue;
-          const msgDecoded = abi.decode(['uint256', 'bytes', 'uint256', 'uint256', 'bytes', 'bytes'], log.data);
-          const payload = msgDecoded[5];
-          const connSn = msgDecoded[2];
-          const msgDstChainId = msgDecoded[3];
-          if (BigInt(connSn).toString() !== BigInt(txConnSn).toString()) continue;
-          const intentDenom = getTokenDenom(dstToken.toLowerCase(), BigInt(dstChainId).toString(), BigInt(srcChainId).toString());
-          const payloadDenom = this.parsePayloadData(payload, BigInt(dstChainId).toString(), BigInt(srcChainId).toString());
-          if (intentDenom !== payloadDenom || msgDstChainId !== dstChainId) {
-            if (intentDenom.includes("USDC") && payloadDenom.includes("USDC")) continue;
-            if (intentDenom.includes("BTCB") && payloadDenom.includes("BTCB")) continue;
-            return {
-              txnFee: `${bigintDivisionToDecimalString(txFee, 18)} ${this.denom}`,
-              payload,
-              intentFilled: false,
-              intentCancelled,
-              dstAddress,
-              intentTxHash: intentHash,
-              blockNumber,
-              storedCallReverted,
-            };
-          }
         }
         let inputToken = intent[2].toLowerCase();
         let decimals = 18;
@@ -444,6 +405,48 @@ export class EvmHandler implements ChainHandler {
     }
     return ""
   };
+}
+
+// Find the Message event whose conn sn matches the message being enriched.
+// Returns its payload, or null when the tx has no matching Message event
+// (e.g. sn missing or the message originated elsewhere).
+function findMessageEventBySn(
+  logs: Array<{ topics?: string[]; data: string }>,
+  txConnSn: string | null | undefined,
+): { payload: string } | null {
+  if (txConnSn === null || txConnSn === undefined || txConnSn === '') return null;
+  let want: bigint;
+  try {
+    want = BigInt(txConnSn);
+  } catch {
+    return null;
+  }
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+  for (const log of logs) {
+    if (!log.topics?.includes(MESSAGE_EVENT_TOPIC)) continue;
+    try {
+      const decoded = abi.decode(['uint256', 'bytes', 'uint256', 'uint256', 'bytes', 'bytes'], log.data);
+      if (BigInt(decoded[2]) === want) {
+        return { payload: decoded[5] };
+      }
+    } catch {
+      // Malformed Message log — skip.
+    }
+  }
+  return null;
+}
+
+// Sender field (index 1) of the 5-field RLP transfer payload, lowercased.
+// Returns null when the payload has another shape — callers must treat
+// that as "unknown", not as "not the intent contract".
+function transferPayloadSender(payload: string): string | null {
+  try {
+    const rlp = RLP.decode(Buffer.from(payload.replace(/^0x/, ''), 'hex'));
+    if (!Array.isArray(rlp) || rlp.length !== 5) return null;
+    return `0x${Buffer.from(rlp[1] as Uint8Array).toString('hex')}`.toLowerCase();
+  } catch {
+    return null;
+  }
 }
 
 function getTokenDenom(decodedAddress: string, srcChainId: string, dstChainId: string) {


### PR DESCRIPTION
A solver tx can carry several relay messages (fill delivery + the solver's own transfers); all of them inherited the tx-level IntentFilled label. Now the message matching txConnSn counts as the fill/cancel delivery only if its payload sender is the contract that emitted the intent event; sibling messages return their own payload and parse as plain transfers.

The old token-name collision checks (with their USDC/BTCB carve-outs for cross-chain name variants like 'Circle USDC') are removed: the sender gate supersedes them, they could not distinguish same-token siblings, and they could wrongly demote real fills on registry name variants for tokens without a carve-out. Their helper params on parseFilledIntentFromInput went with them.

Probe script validates the sender rule against historical fill txs (500 sampled: 0 false demotions, only mislabeled siblings flagged).