### PR TITLE
record cancels of hub-created cross-chain intents

### DIFF
--- a/indexer/src/hub-intents/poller.ts
+++ b/indexer/src/hub-intents/poller.ts
@@ -233,9 +233,6 @@ async function handleCancelled(
   const ctx = await lookupContext(intentHash);
   if (ctx === null) return;
 
-  // Same cross-chain skip as fills: rollback delivery is relayer-indexed.
-  if (ctx.dstChainId !== sonic) return;
-
   const ts = await blockTs.get(log.blockNumber);
   const row: HubEventRow = {
     intentHash,


### PR DESCRIPTION
handleCancelled reused the fills' cross-chain skip (dst != sonic), but the axes differ: fills deliver output to the intent's dst chain, while cancels refund input back to the src chain. For hub-created intents with a spoke dst the refund stays on the hub — no relayer message exists, so the dst-based skip meant nobody recorded the cancel at all.

Drop the skip: a hub create context now only exists for hub-origin intents, and any overlap with a relayer cancel is resolved by the insert guard / enrichment delete.

Backfill: replay the poller from the launch block (delete the cursor file); inserts are idempotent, only missing cancels get written.