### PR TITLE
fix: resolve hub intent token decimals & label by origin

### DIFF
--- a/indexer/scripts/backfill-hub-intent-origin.ts
+++ b/indexer/scripts/backfill-hub-intent-origin.ts
@@ -154,37 +154,50 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Apply: UPDATE only hub rows (sn IS NULL), only when the value actually changes.
-  let cWrote = 0, fWrote = 0;
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-    for (const u of createUpdates) {
-      const r = await client.query(
-        `UPDATE messages SET action_detail=$1, updated_at=extract(epoch from now())::bigint
-           WHERE action_type='CreateIntent' AND sn IS NULL
-             AND lower(intent_tx_hash)=$2 AND action_detail IS DISTINCT FROM $1`,
-        [u.detail, u.intentHash],
-      );
-      cWrote += r.rowCount ?? 0;
+  // Apply in batched, per-chunk-autocommitted UPDATEs (multi-row VALUES join):
+  // ~130 statements instead of ~64k round-trips, and a connection drop only
+  // loses the in-flight chunk — the IS DISTINCT guard makes a re-run resume
+  // (already-fixed rows are skipped). UPDATEs only hub rows (sn IS NULL).
+  const CHUNK = 500;
+  async function applyBatched(
+    label: string,
+    rows: unknown[][],
+    ncols: number,
+    sqlFor: (valuesClause: string) => string,
+  ): Promise<number> {
+    let wrote = 0;
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const slice = rows.slice(i, i + CHUNK);
+      const tuples = slice
+        .map((_, ri) => '(' + Array.from({ length: ncols }, (__, ci) => `$${ri * ncols + ci + 1}::text`).join(',') + ')')
+        .join(',');
+      const r = await pool.query(sqlFor(tuples), slice.flat());
+      wrote += r.rowCount ?? 0;
+      console.log(`  ${label}: ${Math.min(i + CHUNK, rows.length)}/${rows.length} processed, ${wrote} changed`);
     }
-    for (const u of fillUpdates) {
-      const r = await client.query(
-        `UPDATE messages SET action_detail=$1, slippage=$2, updated_at=extract(epoch from now())::bigint
-           WHERE action_type='IntentFilled' AND sn IS NULL
-             AND lower(intent_tx_hash)=$3
-             AND (action_detail IS DISTINCT FROM $1 OR slippage IS DISTINCT FROM $2)`,
-        [u.detail, u.slippage, u.intentHash],
-      );
-      fWrote += r.rowCount ?? 0;
-    }
-    await client.query('COMMIT');
-  } catch (e) {
-    await client.query('ROLLBACK');
-    throw e;
-  } finally {
-    client.release();
+    return wrote;
   }
+
+  const cWrote = await applyBatched(
+    'creates',
+    createUpdates.map(u => [u.intentHash, u.detail]),
+    2,
+    vals => `UPDATE messages m SET action_detail=v.detail, updated_at=extract(epoch from now())::bigint
+             FROM (VALUES ${vals}) AS v(hash, detail)
+             WHERE m.action_type='CreateIntent' AND m.sn IS NULL
+               AND lower(m.intent_tx_hash)=v.hash AND m.action_detail IS DISTINCT FROM v.detail`,
+  );
+  const fWrote = await applyBatched(
+    'fills',
+    fillUpdates.map(u => [u.intentHash, u.detail, u.slippage]),
+    3,
+    vals => `UPDATE messages m SET action_detail=v.detail, slippage=v.slippage, updated_at=extract(epoch from now())::bigint
+             FROM (VALUES ${vals}) AS v(hash, detail, slippage)
+             WHERE m.action_type='IntentFilled' AND m.sn IS NULL
+               AND lower(m.intent_tx_hash)=v.hash
+               AND (m.action_detail IS DISTINCT FROM v.detail OR m.slippage IS DISTINCT FROM v.slippage)`,
+  );
+
   console.log(`APPLIED: ${cWrote} create rows, ${fWrote} fill rows updated.`);
   console.log('NOTE: relayer raw-tuple victims (sn IS NOT NULL) are NOT fixed by this script.');
   await pool.end();

--- a/indexer/scripts/backfill-hub-intent-origin.ts
+++ b/indexer/scripts/backfill-hub-intent-origin.ts
@@ -1,0 +1,193 @@
+/**
+ * One-off backfill: recompute hub-side intent action_detail (+ fill slippage)
+ * from the original Sonic events, resolving token decimals & origin BY ADDRESS.
+ *
+ * Why: the old fill formatter resolved decimals by token *symbol*, which is
+ * ambiguous on the hub (one symbol → many addresses with different decimals,
+ * e.g. USDT at 6 and 18). That produced both wrong numbers (slippage in the
+ * billions of %) and origin-less labels (`USDT(sonic)` instead of
+ * `USDT.bsc(sonic)`). The live code is fixed; this repairs existing rows.
+ *
+ * Approach: re-scan IntentCreated + IntentFilled logs over the hub range
+ * (~2.7M blocks / 5k batch ≈ ~545 getLogs calls), rebuild each CreateIntent
+ * detail by address (so it carries origin + correct decimals), then format
+ * each fill from that corrected create string via the shared formatter. UPDATE
+ * the matching `messages` rows (sn IS NULL only — hub-origin rows).
+ *
+ * SCOPE: hub-side rows only. The relayer raw-tuple victims (sn IS NOT NULL,
+ * "IntentFilled 0x…,") are a separate code path and are NOT touched here.
+ *
+ * Usage:
+ *   ts-node -r dotenv/config scripts/backfill-hub-intent-origin.ts            # dry-run
+ *   ts-node -r dotenv/config scripts/backfill-hub-intent-origin.ts --apply    # write
+ *   …--from <block> --to <block>   override the scan range (default: full history)
+ */
+import { ethers } from 'ethers';
+import { RPC_URLS, sonic, chains, idToChainNameMap, enrichChainsFromApi } from '../src/configs';
+import { bigintDivisionToDecimalString, symbolWithOrigin } from '../src/utils';
+import { formatFillFromCreateActionDetail } from '../src/intent-fill-format';
+import pool from '../src/db/db';
+
+const CONTRACT_ADDRESS = (
+  process.env.HUB_INTENT_CONTRACT || '0x6382D6ccD780758C5e8A6123c33ee8F4472F96ef'
+).toLowerCase();
+const START_BLOCK = Number.parseInt(process.env.HUB_INTENT_START_BLOCK || '18681775', 10);
+const BATCH_SIZE = Number.parseInt(process.env.HUB_INTENT_BATCH_SIZE || '5000', 10);
+const CONFIRMATIONS = Number.parseInt(process.env.HUB_INTENT_CONFIRMATIONS || '12', 10);
+const RPC_SLEEP_MS = Number.parseInt(process.env.BACKFILL_RPC_SLEEP_MS || '150', 10);
+
+const INTENT_CREATED_TOPIC = ethers.keccak256(
+  ethers.toUtf8Bytes(
+    'IntentCreated(bytes32,(uint256,address,address,address,uint256,uint256,uint256,bool,uint256,uint256,bytes,bytes,address,bytes))',
+  ),
+);
+const INTENT_FILLED_TOPIC = ethers.keccak256(
+  ethers.toUtf8Bytes('IntentFilled(bytes32,(bool,uint256,uint256,bool))'),
+);
+const CREATED_TUPLE =
+  '(uint256,address,address,address,uint256,uint256,uint256,bool,uint256,uint256,bytes,bytes,address,bytes)';
+
+const normalizeAddr = (a: string): string =>
+  /^(0x|cx)[0-9a-fA-F]+$/.test(a) ? a.toLowerCase() : a;
+
+function tokenInfo(chainId: string, addr: string): { name: string; decimals: number; origin?: string } {
+  const key = normalizeAddr(addr);
+  const a = chains[chainId]?.Assets?.[key];
+  if (a) return { name: a.name, decimals: a.decimals, origin: a.origin };
+  return { name: addr, decimals: 18 };
+}
+
+// Rebuild a CreateIntent action_detail exactly as poller.handleCreated does —
+// resolving each leg by address so it carries origin + correct decimals.
+function buildCreateDetail(data: string): { intentHash: string; detail: string } {
+  const abi = ethers.AbiCoder.defaultAbiCoder();
+  const decoded = abi.decode(['bytes32', CREATED_TUPLE], data);
+  const intentHash = (decoded[0] as string).toLowerCase();
+  const t = decoded[1] as ethers.Result;
+  const inInfo = tokenInfo((t[8] as bigint).toString(), normalizeAddr(t[2] as string));
+  const outInfo = tokenInfo((t[9] as bigint).toString(), normalizeAddr(t[3] as string));
+  const inAmt = bigintDivisionToDecimalString(t[4] as bigint, inInfo.decimals);
+  const outAmt = bigintDivisionToDecimalString(t[5] as bigint, outInfo.decimals);
+  const srcName = idToChainNameMap[(t[8] as bigint).toString()] || (t[8] as bigint).toString();
+  const dstName = idToChainNameMap[(t[9] as bigint).toString()] || (t[9] as bigint).toString();
+  const detail = `IntentSwap ${inAmt} ${symbolWithOrigin(inInfo, inInfo.name)}(${srcName}) -> ${outAmt} ${symbolWithOrigin(outInfo, outInfo.name)}(${dstName})`;
+  return { intentHash, detail };
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const argFrom = process.argv.indexOf('--from');
+  const argTo = process.argv.indexOf('--to');
+
+  await enrichChainsFromApi(); // populate AssetInfo.origin
+
+  const provider = new ethers.JsonRpcProvider(RPC_URLS[sonic]);
+  const head = (await provider.getBlockNumber()) - CONFIRMATIONS;
+  const from = argFrom >= 0 ? Number.parseInt(process.argv[argFrom + 1], 10) : START_BLOCK;
+  const to = argTo >= 0 ? Number.parseInt(process.argv[argTo + 1], 10) : head;
+  console.log(`mode=${apply ? 'APPLY' : 'DRY-RUN'} contract=${CONTRACT_ADDRESS} range=[${from}, ${to}] batch=${BATCH_SIZE}`);
+
+  const createDetails = new Map<string, string>();             // intentHash → corrected create detail
+  const fills: { intentHash: string; filledRaw: bigint }[] = [];
+
+  let calls = 0;
+  for (let lo = from; lo <= to; lo += BATCH_SIZE) {
+    const hi = Math.min(lo + BATCH_SIZE - 1, to);
+    const logs = await provider.getLogs({
+      address: CONTRACT_ADDRESS,
+      fromBlock: lo,
+      toBlock: hi,
+      topics: [[INTENT_CREATED_TOPIC, INTENT_FILLED_TOPIC]],
+    });
+    calls++;
+    for (const log of logs) {
+      if (log.topics[0] === INTENT_CREATED_TOPIC) {
+        const { intentHash, detail } = buildCreateDetail(log.data);
+        createDetails.set(intentHash, detail);
+      } else {
+        const abi = ethers.AbiCoder.defaultAbiCoder();
+        const t = abi.decode(['(bytes32,bool,uint256,uint256,bool)'], log.data)[0] as ethers.Result;
+        fills.push({ intentHash: (t[0] as string).toLowerCase(), filledRaw: t[3] as bigint });
+      }
+    }
+    if (calls % 25 === 0) console.log(`  scanned to ${hi} — creates=${createDetails.size} fills=${fills.length} (${calls} calls)`);
+    if (RPC_SLEEP_MS > 0) await sleep(RPC_SLEEP_MS);
+  }
+  console.log(`scan done: ${calls} getLogs calls, ${createDetails.size} creates, ${fills.length} fills`);
+
+  // Build the fill rewrites from the corrected create strings.
+  const createUpdates: { intentHash: string; detail: string }[] = [];
+  for (const [intentHash, detail] of createDetails) createUpdates.push({ intentHash, detail });
+
+  const fillUpdates: { intentHash: string; detail: string; slippage: string | null }[] = [];
+  let unresolved = 0;
+  for (const f of fills) {
+    const createDetail = createDetails.get(f.intentHash);
+    if (!createDetail) { unresolved++; continue; }
+    const fmt = formatFillFromCreateActionDetail(createDetail, f.filledRaw);
+    if (!fmt) { unresolved++; continue; }
+    fillUpdates.push({ intentHash: f.intentHash, detail: fmt.actionDetail, slippage: fmt.slippage || null });
+  }
+  console.log(`prepared: ${createUpdates.length} create rewrites, ${fillUpdates.length} fill rewrites, ${unresolved} fills unresolved (no/unparseable create)`);
+
+  // Sample diff vs current DB so dry-run shows real before→after — prefer
+  // implausible-slippage rows (the decimals victims) so the repair is visible.
+  const allHashes = fillUpdates.map(u => u.intentHash);
+  const sample = await pool.query(
+    `SELECT intent_tx_hash, action_detail, slippage FROM messages
+      WHERE action_type='IntentFilled' AND sn IS NULL AND lower(intent_tx_hash) = ANY($1)
+      ORDER BY (slippage ~ '^-?[0-9.]+%$' AND abs(replace(slippage,'%','')::numeric) > 1000) DESC NULLS LAST
+      LIMIT 8`,
+    [allHashes],
+  );
+  console.log('\nsample current fill rows:');
+  for (const r of sample.rows) {
+    const u = fillUpdates.find(x => x.intentHash === r.intent_tx_hash.toLowerCase());
+    console.log(`  ${r.intent_tx_hash}\n    before: ${r.action_detail}  [${r.slippage}]\n    after : ${u?.detail}  [${u?.slippage}]`);
+  }
+
+  if (!apply) {
+    console.log('\nDRY-RUN — no writes. Re-run with --apply to persist.');
+    await pool.end();
+    return;
+  }
+
+  // Apply: UPDATE only hub rows (sn IS NULL), only when the value actually changes.
+  let cWrote = 0, fWrote = 0;
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    for (const u of createUpdates) {
+      const r = await client.query(
+        `UPDATE messages SET action_detail=$1, updated_at=extract(epoch from now())::bigint
+           WHERE action_type='CreateIntent' AND sn IS NULL
+             AND lower(intent_tx_hash)=$2 AND action_detail IS DISTINCT FROM $1`,
+        [u.detail, u.intentHash],
+      );
+      cWrote += r.rowCount ?? 0;
+    }
+    for (const u of fillUpdates) {
+      const r = await client.query(
+        `UPDATE messages SET action_detail=$1, slippage=$2, updated_at=extract(epoch from now())::bigint
+           WHERE action_type='IntentFilled' AND sn IS NULL
+             AND lower(intent_tx_hash)=$3
+             AND (action_detail IS DISTINCT FROM $1 OR slippage IS DISTINCT FROM $2)`,
+        [u.detail, u.slippage, u.intentHash],
+      );
+      fWrote += r.rowCount ?? 0;
+    }
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+  console.log(`APPLIED: ${cWrote} create rows, ${fWrote} fill rows updated.`);
+  console.log('NOTE: relayer raw-tuple victims (sn IS NOT NULL) are NOT fixed by this script.');
+  await pool.end();
+}
+
+main().catch(e => { console.error('backfill failed:', e); process.exit(1); });

--- a/indexer/src/chains/evm/index.ts
+++ b/indexer/src/chains/evm/index.ts
@@ -3,7 +3,7 @@ import { ChainHandler } from "../../types/ChainHandler";
 import { ethers } from 'ethers';
 import { TxPayload } from "../../types";
 import { chains, idToChainNameMap, sonic } from "../../configs";
-import { bigintDivisionToDecimalString } from "../../utils";
+import { bigintDivisionToDecimalString, symbolWithOrigin } from "../../utils";
 import RLP from "rlp";
 import { getHandler } from "../../handler";
 
@@ -174,7 +174,7 @@ export class EvmHandler implements ChainHandler {
           let decimals = 18
           if (inputToken in assetsInformation) {
             const tokenInfo = assetsInformation[inputToken]
-            inputToken = tokenInfo.name
+            inputToken = symbolWithOrigin(tokenInfo, inputToken)
             decimals = tokenInfo.decimals
           }
           const outputAssetsInformation = chains[dstChainId].Assets
@@ -182,7 +182,7 @@ export class EvmHandler implements ChainHandler {
           let outputDecimals = 18
           if (outputToken in outputAssetsInformation) {
             const outputTokenInfo = outputAssetsInformation[outputToken]
-            outputToken = outputTokenInfo.name
+            outputToken = symbolWithOrigin(outputTokenInfo, outputToken)
             outputDecimals = outputTokenInfo.decimals
           }
           let inputAmount = bigintDivisionToDecimalString(decodedIntentFill[1], decimals)
@@ -223,7 +223,7 @@ export class EvmHandler implements ChainHandler {
                   let decimals = 18
                   if (inputToken in assetsInformation) {
                     const inputTokenInfo = assetsInformation[inputToken]
-                    inputToken = inputTokenInfo.name
+                    inputToken = symbolWithOrigin(inputTokenInfo, inputToken)
                     decimals = inputTokenInfo.decimals
                   }
                   const outputAssetsInformation = chains[dstChainId].Assets
@@ -231,7 +231,7 @@ export class EvmHandler implements ChainHandler {
                   let outputDecimals = 18
                   if (outputToken in outputAssetsInformation) {
                     const outputTokenInfo = outputAssetsInformation[outputToken]
-                    outputToken = outputTokenInfo.name
+                    outputToken = symbolWithOrigin(outputTokenInfo, outputToken)
                     outputDecimals = outputTokenInfo.decimals
                   }
                   const inputAmount = bigintDivisionToDecimalString(result[4], decimals)
@@ -350,14 +350,14 @@ export class EvmHandler implements ChainHandler {
         let decimals = 18;
         if (inputToken in srcChain.Assets) {
           const inputTokenInfo = srcChain.Assets[inputToken];
-          inputToken = inputTokenInfo.name;
+          inputToken = symbolWithOrigin(inputTokenInfo, inputToken);
           decimals = inputTokenInfo.decimals;
         }
         let outputToken = intent[3].toLowerCase();
         let outputDecimals = 18;
         if (outputToken in dstChain.Assets) {
           const outputTokenInfo = dstChain.Assets[outputToken];
-          outputToken = outputTokenInfo.name;
+          outputToken = symbolWithOrigin(outputTokenInfo, outputToken);
           outputDecimals = outputTokenInfo.decimals;
         }
         const filledOutput = BigInt(intentFilledValue);

--- a/indexer/src/configs.ts
+++ b/indexer/src/configs.ts
@@ -34,6 +34,16 @@ export type AssetInfo = {
    * force 18; intent contexts should use `decimals` as-is.
    */
   isSodaWrap?: boolean;
+  /**
+   * Spoke chain this asset is the hub-side representation of (e.g. "bsc" for
+   * the Sonic USDT that represents BSC's USDT). Set only on hub entries added
+   * by `enrichChainsFromApi`, and only when the origin differs from the hub
+   * itself. On the hub, many assets share a symbol (15 distinct "USDT"); the
+   * origin disambiguates them — both for display (USDT.bsc(sonic)) and for
+   * resolving the correct decimals, which vary by origin (BSC USDT is 18, the
+   * rest 6). Absent for native/spoke-side entries.
+   */
+  origin?: string;
 };
 
 type ChainAssets = {
@@ -191,6 +201,7 @@ export async function enrichChainsFromApi(): Promise<void> {
     }
     const chainEntry = chains[chainId];
     if (!chainEntry) continue; // chain not configured locally — skip
+    const originName = idToChainNameMap[chainId] ?? chainId;
     for (const [addr, info] of Object.entries(assets)) {
       const entry: AssetInfo = {
         name: info.symbol || info.name,
@@ -205,7 +216,15 @@ export async function enrichChainsFromApi(): Promise<void> {
       // on so tokenInfo(chainId, address) lookups succeed regardless of
       // which side an intent references.
       if (register(chainEntry, addr, entry)) added++;
-      if (info.asset && hubChain && register(hubChain, info.asset, entry)) added++;
+      // The hub-side entry carries its origin so same-symbol reps stay
+      // distinguishable (decimals differ by origin). A separate object — the
+      // spoke-side `entry` must stay origin-free. Don't tag hub-native assets
+      // (origin === hub) — they render plainly as SYMBOL(sonic).
+      if (info.asset && hubChain) {
+        const hubEntry: AssetInfo =
+          chainId === sonic ? entry : { ...entry, origin: originName };
+        if (register(hubChain, info.asset, hubEntry)) added++;
+      }
     }
   }
   console.log(`enrichChainsFromApi: added ${added} asset entries from hub/assets API.`);

--- a/indexer/src/hub-intents/poller.ts
+++ b/indexer/src/hub-intents/poller.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { RPC_URLS, sonic, chains, idToChainNameMap } from '../configs';
-import { bigintDivisionToDecimalString } from '../utils';
+import { bigintDivisionToDecimalString, symbolWithOrigin } from '../utils';
 import { formatFillFromCreateActionDetail } from '../intent-fill-format';
 import {
   CreatedContext,
@@ -82,11 +82,15 @@ function normalizeAddr(addr: string): string {
   return /^(0x|cx)[0-9a-fA-F]+$/.test(addr) ? addr.toLowerCase() : addr;
 }
 
-function tokenInfo(chainId: string, addr: string): { name: string; decimals: number } {
+function tokenInfo(
+  chainId: string,
+  addr: string,
+): { name: string; decimals: number; origin?: string } {
   const key = normalizeAddr(addr);
   const assets = chains[chainId]?.Assets;
   if (assets && key in assets) {
-    return { name: assets[key].name, decimals: assets[key].decimals };
+    const a = assets[key];
+    return { name: a.name, decimals: a.decimals, origin: a.origin };
   }
   // Unknown token: action_detail will use the raw address as the symbol and
   // fall back to 18 decimals, which is wrong for USDC (6), WBTC (8), etc.
@@ -156,7 +160,9 @@ async function handleCreated(
   const outAmt = bigintDivisionToDecimalString(minOutputAmountRaw, outInfo.decimals);
   const srcName = idToChainNameMap[tupleSrcChainId] || tupleSrcChainId;
   const dstName = idToChainNameMap[tupleDstChainId] || tupleDstChainId;
-  const actionDetail = `IntentSwap ${inAmt} ${inInfo.name}(${srcName}) -> ${outAmt} ${outInfo.name}(${dstName})`;
+  const inSym = symbolWithOrigin(inInfo, inInfo.name);
+  const outSym = symbolWithOrigin(outInfo, outInfo.name);
+  const actionDetail = `IntentSwap ${inAmt} ${inSym}(${srcName}) -> ${outAmt} ${outSym}(${dstName})`;
 
   const ts = await blockTs.get(log.blockNumber);
   const row: HubEventRow = {

--- a/indexer/src/intent-fill-format.ts
+++ b/indexer/src/intent-fill-format.ts
@@ -17,7 +17,11 @@ export interface FillFormatResult {
   slippage: string;
 }
 
-const CREATE_RE = /^IntentSwap\s+([0-9.]+)\s+(\S+?)\((\w+)\)\s*->\s*([0-9.]+)\s+(\S+?)\((\w+)\)\s*$/;
+// Matches the OUTPUT leg of an IntentSwap create — all the fill needs. Greedy
+// name + end-anchored chain so multi-word / parenthesised token names parse
+// correctly (e.g. "Circle USDC", "bnUSD (legacy)"); a `\S+?` name would break
+// on the space. Captures: 1=min output amount, 2=symbol[.origin], 3=chain.
+const CREATE_RE = /->\s*([0-9.]+)\s+(.+?)\s*\((\w+)\)\s*$/;
 
 const chainNameToId: Record<string, string> = Object.fromEntries(
   Object.entries(idToChainNameMap).map(([id, name]) => [name, id]),
@@ -82,12 +86,12 @@ export function formatFillFromCreateActionDetail(
 ): FillFormatResult | null {
   const m = CREATE_RE.exec(createActionDetail);
   if (!m) return null;
-  const minOutputStr = m[4];
-  // m[5] is the rendered leg symbol, possibly origin-tagged ("USDT.bsc").
+  const minOutputStr = m[1];
+  // m[2] is the rendered leg symbol, possibly origin-tagged ("USDT.bsc").
   // Split it back into name + origin to resolve the right decimals; reuse the
   // tagged label verbatim in the fill so create and fill read identically.
-  const outputTokenLabel = m[5];
-  const dstChainName = m[6];
+  const outputTokenLabel = m[2];
+  const dstChainName = m[3];
   const dot = outputTokenLabel.indexOf('.');
   const outputTokenName = dot >= 0 ? outputTokenLabel.slice(0, dot) : outputTokenLabel;
   const outputOrigin = dot >= 0 ? outputTokenLabel.slice(dot + 1) : undefined;

--- a/indexer/src/intent-fill-format.ts
+++ b/indexer/src/intent-fill-format.ts
@@ -23,11 +23,25 @@ const chainNameToId: Record<string, string> = Object.fromEntries(
   Object.entries(idToChainNameMap).map(([id, name]) => [name, id]),
 );
 
-function decimalsForTokenName(chainId: string, tokenName: string): number | null {
+/**
+ * Resolve decimals for an output leg by (symbol, origin) rather than symbol
+ * alone. On the hub, one symbol maps to many addresses with different decimals
+ * (e.g. USDT: 6 for most origins, 18 for BSC); the origin parsed out of the
+ * create string ("USDT.bsc" → origin "bsc") makes the match unique. A bare
+ * symbol (no origin) matches the native/spoke-side entry, which has no origin.
+ */
+function decimalsForTokenName(
+  chainId: string,
+  tokenName: string,
+  origin?: string,
+): number | null {
   const assets = chains[chainId]?.Assets;
   if (!assets) return null;
   for (const addr of Object.keys(assets)) {
-    if (assets[addr].name === tokenName) return assets[addr].decimals;
+    const a = assets[addr];
+    if (a.name === tokenName && (a.origin ?? undefined) === (origin ?? undefined)) {
+      return a.decimals;
+    }
   }
   return null;
 }
@@ -69,16 +83,22 @@ export function formatFillFromCreateActionDetail(
   const m = CREATE_RE.exec(createActionDetail);
   if (!m) return null;
   const minOutputStr = m[4];
-  const outputTokenName = m[5];
+  // m[5] is the rendered leg symbol, possibly origin-tagged ("USDT.bsc").
+  // Split it back into name + origin to resolve the right decimals; reuse the
+  // tagged label verbatim in the fill so create and fill read identically.
+  const outputTokenLabel = m[5];
   const dstChainName = m[6];
+  const dot = outputTokenLabel.indexOf('.');
+  const outputTokenName = dot >= 0 ? outputTokenLabel.slice(0, dot) : outputTokenLabel;
+  const outputOrigin = dot >= 0 ? outputTokenLabel.slice(dot + 1) : undefined;
 
   const dstChainId = chainNameToId[dstChainName];
   if (!dstChainId) return null;
-  const decimals = decimalsForTokenName(dstChainId, outputTokenName);
+  const decimals = decimalsForTokenName(dstChainId, outputTokenName, outputOrigin);
   if (decimals == null) return null;
 
   const formatted = bigintDivisionToDecimalString(filledRaw, decimals);
-  const actionDetail = `IntentFilled ${formatted} ${outputTokenName}(${dstChainName})`;
+  const actionDetail = `IntentFilled ${formatted} ${outputTokenLabel}(${dstChainName})`;
 
   let slippage = '';
   try {

--- a/indexer/src/utils.ts
+++ b/indexer/src/utils.ts
@@ -50,6 +50,21 @@ export function getErc20Decimals(asset: AssetInfo): number {
   return asset.isSodaWrap ? 18 : asset.decimals;
 }
 
+/**
+ * Symbol to render for a swap leg, disambiguating hub representations by their
+ * origin chain: "USDT.bsc" for the BSC-origin hub USDT, plain "USDT" for
+ * native/spoke-side assets. `origin` is set only on hub entries (see
+ * AssetInfo.origin). Falls back to `fallback` (typically the raw address) when
+ * the asset isn't known.
+ */
+export function symbolWithOrigin(
+  asset: { name: string; origin?: string } | undefined,
+  fallback: string,
+): string {
+  if (!asset) return fallback;
+  return asset.origin ? `${asset.name}.${asset.origin}` : asset.name;
+}
+
 export function resolveMoneyMarketActionText(
   action: string,
   amount: bigint,


### PR DESCRIPTION
Hub assets share symbols (e.g. 15 USDTs), so resolving fill decimals by name picked the wrong scale. Tag each hub-rep with its origin chain and resolve by (symbol, origin); render SYMBOL.origin(sonic). Adds a backfill to repair existing rows.